### PR TITLE
fixed mis-matched iso3 codes for North/South Korea

### DIFF
--- a/2014_world_gdp_with_codes.csv
+++ b/2014_world_gdp_with_codes.csv
@@ -106,8 +106,8 @@ Jordan,36.55,JOR
 Kazakhstan,225.60,KAZ
 Kenya,62.72,KEN
 Kiribati,0.16,KIR
-"Korea, North",28.00,KOR
-"Korea, South",1410.00,PRK
+"Korea, North",28.00,PRK
+"Korea, South",1410.00,KOR
 Kosovo,5.99,KSV
 Kuwait,179.30,KWT
 Kyrgyzstan,7.65,KGZ


### PR DESCRIPTION
This issue was causing troubles when this dataset was used as a template.

Thanks to @bjoyce3 for noticing!!
