### PR TITLE
added retail sales and 5 point Likert example data for bar charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 | 2014 world GDP | Maps | Unknown | [R](https://plot.ly/r/choropleth-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2014_world_gdp_with_codes.csv) | [Open](https://plot.ly/7936/~Dreamshot/) |
 | 2015 precipitation | Maps | Unknown | [Python](https://plot.ly/python/scatter-plots-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2015_06_30_precipitation.csv) | [Open](https://plot.ly/7938/~Dreamshot/) |
 | 2024 retail sales as a percentage of annual total | Basic | adapted from [US Census Bureau](https://www.census.gov/retail/sales.html) | [Python](https://plotly.com/python/horizontal-bar-charts/) | [Download](https://github.com/plotly/datasets/blob/master/retail_sales_percent_of_annual_total_2024.csv) | N.A. |
-
 | Alpha shapes | Alpha Shapes | Unknown | [Python](https://plot.ly/python/alpha-shapes/) | [Download](https://github.com/plotly/datasets/blob/master/alpha_shape.csv) | [Open](https://plot.ly/7940/~Dreamshot/) |
 | Grouped bar charts with Excel | Basic | Unknown | [Excel](http://help.plot.ly/excel/grouped-bar-chart/) | [Download](https://github.com/plotly/datasets/blob/master/bar-charts-with-excel.csv) | [Open](https://plot.ly/7942/~Dreamshot/) |
 | Bubble charts with Excel | Basic | Unknown | [Excel](http://help.plot.ly/excel/bubble-chart/) | [Download](https://github.com/plotly/datasets/blob/master/bubble_chart_tutorial.csv) | [Open](https://plot.ly/7944/~Dreamshot/) |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 | Dataset name | Best for | Origin | Chart example | Download | Open in Plotly |
 | --- | --- | --- | ---  | ---  | ---  |
-
 | 2010 alchohol consumption by country | Maps | Unknown | [JavaScript](https://plot.ly/javascript/choropleth-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2010_alcohol_consumption_by_country.csv) | [Open](https://plot.ly/16265/~jackp/) |
 | 2011 February AA flight paths | Maps | Unknown | [Python](https://plot.ly/python/lines-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2011_february_aa_flight_paths.csv) | [Open](https://plot.ly/7924/~Dreamshot/) |
 | 2011 February US airport traffic | Maps | Unknown | [JavaScript](https://plot.ly/javascript/scatter-plots-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2011_february_us_airport_traffic.csv) | [Open](https://plot.ly/7926/~Dreamshot/) |
@@ -29,7 +28,7 @@
 | Dot plot with Excel | Multiple Axes | Unknown | [Excel](http://help.plot.ly/excel/dot-plots/) | [Download](https://github.com/plotly/datasets/blob/master/dot-plot-with-excel.csv) | [Open](https://plot.ly/7948/~Dreamshot/) |
 | Gapminder data | Streaming | [Jenny Bryan](https://github.com/jennybc/gapminder) | [Python](https://plot.ly/python/streaming-bubbles-tutorial/) | [Download](https://github.com/plotly/datasets/blob/master/gapminderDataFiveYear.csv) | [Open](https://plot.ly/7950/~Dreamshot/) |
 | Globe contours | Maps | Unknown | [Python](https://plot.ly/python/lines-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/globe_contours.csv) | [Open](https://plot.ly/7952/~Dreamshot/) |
-| Likert Scale responses, 2002 General Social Survey altruism questions | Basic | adapted from [General Social Survey, 2002]([https://www.census.gov/retail/sales.html](https://gssdataexplorer.norc.org/)) | [Python](https://plotly.com/python/horizontal-bar-charts/) | [Download](https://github.com/plotly/datasets/blob/master/gss_2002_5_pt_likert.csv) | N.A. |
+| Likert Scale responses, 2002 General Social Survey altruism questions | Basic | adapted from [General Social Survey, 2002](https://gssdataexplorer.norc.org/) | [Python](https://plotly.com/python/horizontal-bar-charts/) | [Download](https://github.com/plotly/datasets/blob/master/gss_2002_5_pt_likert.csv) | N.A. |
 | Inset plot | Multiple Axes | Unknown | [Excel](http://help.plot.ly/excel/insets) | [Download](https://github.com/plotly/datasets/blob/master/inset.csv) | [Open](https://plot.ly/7954/~Dreamshot/) |
 | Text scatter charts | Basic | Unknown | [Excel](http://help.plot.ly/excel/text-scatter-chart) | [Download](https://github.com/plotly/datasets/blob/master/label-text.csv) | [Open](https://plot.ly/7956/~Dreamshot/) |
 | LaTeX typesetting | Basic | Unknown | [Excel](http://help.plot.ly/excel/LaTeX) | [Download](https://github.com/plotly/datasets/blob/master/latex-typesetting-with-excel.csv) | [Open](https://plot.ly/7958/~Dreamshot/) |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 | Dataset name | Best for | Origin | Chart example | Download | Open in Plotly |
 | --- | --- | --- | ---  | ---  | ---  |
+
 | 2010 alchohol consumption by country | Maps | Unknown | [JavaScript](https://plot.ly/javascript/choropleth-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2010_alcohol_consumption_by_country.csv) | [Open](https://plot.ly/16265/~jackp/) |
 | 2011 February AA flight paths | Maps | Unknown | [Python](https://plot.ly/python/lines-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2011_february_aa_flight_paths.csv) | [Open](https://plot.ly/7924/~Dreamshot/) |
 | 2011 February US airport traffic | Maps | Unknown | [JavaScript](https://plot.ly/javascript/scatter-plots-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2011_february_us_airport_traffic.csv) | [Open](https://plot.ly/7926/~Dreamshot/) |
@@ -28,6 +29,7 @@
 | Dot plot with Excel | Multiple Axes | Unknown | [Excel](http://help.plot.ly/excel/dot-plots/) | [Download](https://github.com/plotly/datasets/blob/master/dot-plot-with-excel.csv) | [Open](https://plot.ly/7948/~Dreamshot/) |
 | Gapminder data | Streaming | [Jenny Bryan](https://github.com/jennybc/gapminder) | [Python](https://plot.ly/python/streaming-bubbles-tutorial/) | [Download](https://github.com/plotly/datasets/blob/master/gapminderDataFiveYear.csv) | [Open](https://plot.ly/7950/~Dreamshot/) |
 | Globe contours | Maps | Unknown | [Python](https://plot.ly/python/lines-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/globe_contours.csv) | [Open](https://plot.ly/7952/~Dreamshot/) |
+| Likert Scale responses, 2002 General Social Survey altruism questions | Basic | adapted from [General Social Survey, 2002]([https://www.census.gov/retail/sales.html](https://gssdataexplorer.norc.org/)) | [Python](https://plotly.com/python/horizontal-bar-charts/) | [Download](https://github.com/plotly/datasets/blob/master/gss_2002_5_pt_likert.csv) | N.A. |
 | Inset plot | Multiple Axes | Unknown | [Excel](http://help.plot.ly/excel/insets) | [Download](https://github.com/plotly/datasets/blob/master/inset.csv) | [Open](https://plot.ly/7954/~Dreamshot/) |
 | Text scatter charts | Basic | Unknown | [Excel](http://help.plot.ly/excel/text-scatter-chart) | [Download](https://github.com/plotly/datasets/blob/master/label-text.csv) | [Open](https://plot.ly/7956/~Dreamshot/) |
 | LaTeX typesetting | Basic | Unknown | [Excel](http://help.plot.ly/excel/LaTeX) | [Download](https://github.com/plotly/datasets/blob/master/latex-typesetting-with-excel.csv) | [Open](https://plot.ly/7958/~Dreamshot/) |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 | Dataset name | Best for | Origin | Chart example | Download | Open in Plotly |
 | --- | --- | --- | ---  | ---  | ---  |
-| Walmart store openings | Maps | Unknown | [Python](https://plot.ly/python/map-subplots-and-small-multiples/) | [Download](https://github.com/plotly/datasets/blob/master/1962_2006_walmart_store_openings.csv) | [Open](https://plot.ly/16263/~jackp/) |
 | 2010 alchohol consumption by country | Maps | Unknown | [JavaScript](https://plot.ly/javascript/choropleth-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2010_alcohol_consumption_by_country.csv) | [Open](https://plot.ly/16265/~jackp/) |
 | 2011 February AA flight paths | Maps | Unknown | [Python](https://plot.ly/python/lines-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2011_february_aa_flight_paths.csv) | [Open](https://plot.ly/7924/~Dreamshot/) |
 | 2011 February US airport traffic | Maps | Unknown | [JavaScript](https://plot.ly/javascript/scatter-plots-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2011_february_us_airport_traffic.csv) | [Open](https://plot.ly/7926/~Dreamshot/) |
@@ -21,6 +20,8 @@
 | 2014 US states population | Maps | Unknown | [Python](https://plot.ly/python/bubble-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2014_usa_states.csv) | [Open](https://plot.ly/7934/~Dreamshot/) |
 | 2014 world GDP | Maps | Unknown | [R](https://plot.ly/r/choropleth-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2014_world_gdp_with_codes.csv) | [Open](https://plot.ly/7936/~Dreamshot/) |
 | 2015 precipitation | Maps | Unknown | [Python](https://plot.ly/python/scatter-plots-on-maps/) | [Download](https://github.com/plotly/datasets/blob/master/2015_06_30_precipitation.csv) | [Open](https://plot.ly/7938/~Dreamshot/) |
+| 2024 retail sales as a percentage of annual total | Basic | adapted from [US Census Bureau](https://www.census.gov/retail/sales.html) | [Python](https://plotly.com/python/horizontal-bar-charts/) | [Download](https://github.com/plotly/datasets/blob/master/retail_sales_percent_of_annual_total_2024.csv) | N.A. |
+
 | Alpha shapes | Alpha Shapes | Unknown | [Python](https://plot.ly/python/alpha-shapes/) | [Download](https://github.com/plotly/datasets/blob/master/alpha_shape.csv) | [Open](https://plot.ly/7940/~Dreamshot/) |
 | Grouped bar charts with Excel | Basic | Unknown | [Excel](http://help.plot.ly/excel/grouped-bar-chart/) | [Download](https://github.com/plotly/datasets/blob/master/bar-charts-with-excel.csv) | [Open](https://plot.ly/7942/~Dreamshot/) |
 | Bubble charts with Excel | Basic | Unknown | [Excel](http://help.plot.ly/excel/bubble-chart/) | [Download](https://github.com/plotly/datasets/blob/master/bubble_chart_tutorial.csv) | [Open](https://plot.ly/7944/~Dreamshot/) |
@@ -35,6 +36,7 @@
 | Online dating | Multiple Axes | Unknown | [Excel](http://help.plot.ly/excel/graph-with-multiple-axes/) | [Download](https://github.com/plotly/datasets/blob/master/multiple_y_axis.csv) | [Open](https://plot.ly/7960/~Dreamshot/) |
 | OKCupid compatibility by religion | Basic | Unknown | [Excel](http://help.plot.ly/excel/heatmap) | [Download](https://github.com/plotly/datasets/blob/master/okcupid-compatibility-by-religion.csv) | [Open](https://plot.ly/7962/~Dreamshot/) |
 | Pareto chart | Basic | Unknown | [Excel](http://help.plot.ly/excel/pareto-chart) | [Download](https://github.com/plotly/datasets/blob/master/pareto-chart.csv) | [Open](https://plot.ly/7964/~Dreamshot/) |
+| Prostate cancer | Clustergram | [Gene Expression Omnibus](https://www.ncbi.nlm.nih.gov/geo/) | [Dash Bio](https://dash-bio.plotly.host/dash-clustergram/) | [Download](https://github.com/plotly/datasets/blob/master/clustergram_GDS5373.soft) | NA |
 | School earnings | Dumbbell Plots | Unknown | [R](https://plot.ly/r/dumbbell-plots/) | [Download](https://github.com/plotly/datasets/blob/master/school_earnings.csv) | [Open](https://plot.ly/7966/~Dreamshot/) |
 | Shaded regions | Basic | Unknown | [Excel](http://help.plot.ly/excel/shaded-region-on-chart) | [Download](https://github.com/plotly/datasets/blob/master/shaded-region.csv) | [Open](https://plot.ly/7968/~Dreamshot/) |
 | Spectral | Ribbon Plots | Unknown | [Python](https://plot.ly/python/ribbon-plots/) | [Download](https://github.com/plotly/datasets/blob/master/spectral.csv) | [Open](https://plot.ly/7970/~Dreamshot/) |
@@ -43,6 +45,6 @@
 | Time series with error bars | Statistical | Unknown | [Excel](http://help.plot.ly/excel/time-series) | [Download](https://github.com/plotly/datasets/blob/master/time-series-with-error-bars-excel.csv) | [Open](https://plot.ly/7976/~Dreamshot/) |
 | Time series dataframe | Statistical | Unknown | [Pandas](https://plot.ly/pandas/time-series/) | [Download](https://github.com/plotly/datasets/blob/master/timeseries.csv) | [Open](https://plot.ly/7978/~Dreamshot/) |
 | Volcano | Maps | Unknown | [Pandas](https://plot.ly/pandas/3d-surface-plots/) | [Download](https://github.com/plotly/datasets/blob/master/volcano.csv) | [Open](https://plot.ly/7980/~Dreamshot/) |
+| Walmart store openings | Maps | Unknown | [Python](https://plot.ly/python/map-subplots-and-small-multiples/) | [Download](https://github.com/plotly/datasets/blob/master/1962_2006_walmart_store_openings.csv) | [Open](https://plot.ly/16263/~jackp/) |
 | Wind rose | Maps | Unknown | [Python](https://plot.ly/python/wind-rose-charts/) | [Download](https://github.com/plotly/datasets/blob/master/wind_rose.csv) | [Open](https://plot.ly/7982/~Dreamshot/) |
 | Wind speed | Statistical | Unknown | [Pandas](https://plot.ly/pandas/error-bars/) | [Download](https://github.com/plotly/datasets/blob/master/wind_speed_laurel_nebraska.csv) | [Open](https://plot.ly/7984/~Dreamshot/) |
-| Prostate cancer | Clustergram | [Gene Expression Omnibus](https://www.ncbi.nlm.nih.gov/geo/) | [Dash Bio](https://dash-bio.plotly.host/dash-clustergram/) | [Download](https://github.com/plotly/datasets/blob/master/clustergram_GDS5373.soft) | NA |

--- a/gss_2002_5_pt_likert.csv
+++ b/gss_2002_5_pt_likert.csv
@@ -1,0 +1,5 @@
+﻿,Strongly Agree,Agree,Neither Agree nor Disagree,Disagree,Strongly Disagree,source
+People should … help others who are less fortunate,41.93786982,47.18934911,9.097633136,1.109467456,0.665680473,https://gssdataexplorer.norc.org/variables/2890/vshow
+People who are better off should help friends who are less well off,16.84587814,42.11469534,32.25806452,8.154121864,0.627240143,https://gssdataexplorer.norc.org/variables/4231/vshow
+You should take care of yourself and your family first…,43.3713784,39.94732221,12.81826163,3.599648815,0.263388938,https://gssdataexplorer.norc.org/variables/4230/vshow
+Those in need have to learn to take care of themselves…,12.94378698,40.82840237,23.59467456,18.78698225,3.846153846,https://gssdataexplorer.norc.org/variables/2891/vshow

--- a/retail_sales_percent_of_annual_total_2024.csv
+++ b/retail_sales_percent_of_annual_total_2024.csv
@@ -1,0 +1,6 @@
+﻿Retailer Type,Q1,Q2,Q3,Q4
+Gas stations,23.23%,26.56%,26.23%,23.98%
+Sporting Goods Stores,21.86%,25.04%,25.40%,27.70%
+Building Mat & Garden Equip & Supplies,21.41%,27.87%,25.89%,24.82%
+Hobby Toy & Game Stores,21.48%,20.61%,22.31%,35.59%
+Dep't Stores Excluding Discount Dep't stores,20.46%,24.41%,21.92%,33.21%


### PR DESCRIPTION
I plan to use the retail data in https://github.com/plotly/plotly.py/pull/4995

These data are aggregated from the Estimates of Monthly Retail and Food Services Sales by Kind of Business: 2024 https://www.census.gov/retail/sales.html including projected values for December

Thanks to Ken Letzler for converting the Census table into the example data we need.

I plan to use the GSS data in https://github.com/plotly/plotly.py/pull/4994 and https://github.com/plotly/plotly.py/pull/4984 

I also put the readme table back into alphabetical order.